### PR TITLE
Support localization

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,8 @@
+arb-dir: lib/l10n
+template-arb-file: intl_en.arb
+output-localization-file: l10n.dart
+output-class: SLL
+synthetic-package: false
+output-dir: lib/generated
+preferred-supported-locales: en
+nullable-getter: false

--- a/lib/com/hydrologis/flutterlibs/forms/forms.dart
+++ b/lib/com/hydrologis/flutterlibs/forms/forms.dart
@@ -193,7 +193,7 @@ abstract class IConstraint {
   /// Getter for the description of the constraint.
   ///
   /// @return the description of the constraint.
-  String getDescription();
+  String getDescription(BuildContext context);
 }
 
 /// A set of constraints.
@@ -241,12 +241,12 @@ class Constraints {
   }
 
   // Get human readable description of the constraint.
-  String getDescription() {
+  String getDescription(BuildContext context) {
     StringBuffer sb = StringBuffer();
     for (int i = 0; i < constraints.length; i++) {
       IConstraint constraint = constraints[i];
       sb.write(",");
-      sb.write(constraint.getDescription());
+      sb.write(constraint.getDescription(context));
     }
 
     if (sb.isEmpty) {
@@ -283,8 +283,8 @@ class MandatoryConstraint implements IConstraint {
     return _isValid;
   }
 
-  String getDescription() {
-    return _description;
+  String getDescription(BuildContext context) {
+    return SLL.of(context).forms_mandatory;
   }
 }
 
@@ -345,7 +345,7 @@ class RangeConstraint implements IConstraint {
     return _isValid;
   }
 
-  String getDescription() {
+  String getDescription(BuildContext context) {
     StringBuffer sb = new StringBuffer();
     if (includeLow) {
       sb.write("[");

--- a/lib/com/hydrologis/flutterlibs/forms/forms_widgets.dart
+++ b/lib/com/hydrologis/flutterlibs/forms/forms_widgets.dart
@@ -315,14 +315,14 @@ ListTile? getWidget(
           key: ValueKey(widgetKey),
           validator: (value) {
             if (value != null && !constraints.isValid(value)) {
-              return constraints.getDescription();
+              return constraints.getDescription(context);
             }
             return null;
           },
           autovalidateMode: AutovalidateMode.always,
           decoration: InputDecoration(
 //            icon: icon,
-            labelText: "$label ${constraints.getDescription()}",
+            labelText: "$label ${constraints.getDescription(context)}",
           ),
           initialValue: value,
           onChanged: (text) {
@@ -1459,8 +1459,8 @@ class PicturesWidgetState extends State<PicturesWidget> with AfterLayoutMixin {
                                 ),
                                 SmashUI.normalText(
                                     widget.fromGallery
-                                        ? "Load image"
-                                        : "Take a picture",
+                                        ? SLL.of(context).formsWidgets_loadImage //"Load image"
+                                        : SLL.of(context).formsWidgets_takePicture, //"Take a picture"
                                     color: SmashColors.mainDecorations,
                                     bold: true),
                               ],

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'l10n_en.dart';
+import 'l10n_ja.dart';
+
+/// Callers can lookup localized strings with an instance of SLL
+/// returned by `SLL.of(context)`.
+///
+/// Applications need to include `SLL.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'generated/l10n.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: SLL.localizationsDelegates,
+///   supportedLocales: SLL.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the SLL.supportedLocales
+/// property.
+abstract class SLL {
+  SLL(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static SLL of(BuildContext context) {
+    return Localizations.of<SLL>(context, SLL)!;
+  }
+
+  static const LocalizationsDelegate<SLL> delegate = _SLLDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('ja')
+  ];
+
+  /// No description provided for @formsWidgets_loadImage.
+  ///
+  /// In en, this message translates to:
+  /// **'Load image'**
+  String get formsWidgets_loadImage;
+
+  /// No description provided for @formsWidgets_takePicture.
+  ///
+  /// In en, this message translates to:
+  /// **'Take a picture'**
+  String get formsWidgets_takePicture;
+
+  /// No description provided for @forms_mandatory.
+  ///
+  /// In en, this message translates to:
+  /// **'mandatory'**
+  String get forms_mandatory;
+}
+
+class _SLLDelegate extends LocalizationsDelegate<SLL> {
+  const _SLLDelegate();
+
+  @override
+  Future<SLL> load(Locale locale) {
+    return SynchronousFuture<SLL>(lookupSLL(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) => <String>['en', 'ja'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_SLLDelegate old) => false;
+}
+
+SLL lookupSLL(Locale locale) {
+
+
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en': return SLLEn();
+    case 'ja': return SLLJa();
+  }
+
+  throw FlutterError(
+    'SLL.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
+}

--- a/lib/generated/l10n_en.dart
+++ b/lib/generated/l10n_en.dart
@@ -1,0 +1,15 @@
+import 'l10n.dart';
+
+/// The translations for English (`en`).
+class SLLEn extends SLL {
+  SLLEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get formsWidgets_loadImage => 'Load image';
+
+  @override
+  String get formsWidgets_takePicture => 'Take a picture';
+
+  @override
+  String get forms_mandatory => 'mandatory';
+}

--- a/lib/generated/l10n_ja.dart
+++ b/lib/generated/l10n_ja.dart
@@ -1,0 +1,15 @@
+import 'l10n.dart';
+
+/// The translations for Japanese (`ja`).
+class SLLJa extends SLL {
+  SLLJa([String locale = 'ja']) : super(locale);
+
+  @override
+  String get formsWidgets_loadImage => '画像を読み込む';
+
+  @override
+  String get formsWidgets_takePicture => '写真を撮る';
+
+  @override
+  String get forms_mandatory => '必須';
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,0 +1,6 @@
+{
+  "@@locale": "en",
+  "formsWidgets_loadImage": "Load image",
+  "formsWidgets_takePicture": "Take a picture",
+  "forms_mandatory": "mandatory"
+}

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -1,0 +1,6 @@
+{
+  "@@locale": "ja",
+  "formsWidgets_loadImage": "画像を読み込む",
+  "formsWidgets_takePicture": "写真を撮る",
+  "forms_mandatory": "必須"
+}

--- a/lib/smashlibs.dart
+++ b/lib/smashlibs.dart
@@ -30,6 +30,7 @@ import 'package:flutter_screen_wake/flutter_screen_wake.dart';
 import 'package:share_extend/share_extend.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:smashlibs/com/hydrologis/flutterlibs/utils/logging.dart';
+import 'package:smashlibs/generated/l10n.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:wkt_parser/wkt_parser.dart' as wkt_parser;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,6 +181,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_material_pickers:
     dependency: "direct main"
     description:
@@ -294,7 +299,7 @@ packages:
     source: hosted
     version: "2.6.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,10 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_localizations:
+    sdk: flutter
+  intl: '>=0.16.1 <=0.17.0'
+
   ##################
   # OWN
   #################


### PR DESCRIPTION
Supports #2

Support localization like import/export plugins.
Currently, support only `en` and `ja`.

Note that SMASH main app (https://github.com/geopaparazzi/smash) side needs to be updated as follows.
```diff
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:smash/eu/hydrologis/smash/project/projects_view.dart';
 import 'package:smash/eu/hydrologis/smash/util/fence.dart';
 import 'package:smash_import_export_plugins/generated/l10n.dart';
 import 'package:smashlibs/com/hydrologis/flutterlibs/utils/logging.dart';
+import 'package:smashlibs/generated/l10n.dart';
 import 'package:smashlibs/smashlibs.dart';
 import 'package:stack_trace/stack_trace.dart';
 
@@ -77,6 +78,7 @@ class SmashApp extends StatelessWidget {
       localizationsDelegates: [
         SL.delegate,
         IEL.delegate,
+        SLL.delegate,
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
```